### PR TITLE
feat: 适配官网 .com → .ai 域名升级，域名改为从配置 base_url 读取

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Claude Code 状态栏增强插件 v2.0
 
-这是一个用于 Claude Code 的状态栏增强插件，可以在状态栏显示 aicodemirror.com 的余额、实时使用量、计划类型、当前模型、Git 分支状态等信息。
+这是一个用于 Claude Code 的状态栏增强插件，可以在状态栏显示 aicodemirror 的余额、实时使用量、计划类型、当前模型、Git 分支状态等信息。
 
 ## ✨ 功能特性
 
-- 💎 **余额显示**：实时显示 aicodemirror.com 余额和计划类型
+- 💎 **余额显示**：实时显示 aicodemirror 余额和计划类型
 - 📊 **使用量监控** ：显示最近1小时的实时使用量，精确掌握消费情况
 - 🤖 **模型信息**：显示当前使用的 Claude 模型版本
 - 🎨 **输出风格**：显示当前 Claude 输出风格配置
@@ -65,9 +65,9 @@ git clone https://github.com/Bozhu12/cc-aicodemirror-statusline-plus.git .
 
 ### 3. 获取并配置 Cookie
 
-#### 步骤 1：登录 aicodemirror.com
+#### 步骤 1：登录 aicodemirror 官网
 
-1. 打开浏览器，访问 https://www.aicodemirror.com/dashboard
+1. 打开浏览器，访问 https://www.aicodemirror.ai/dashboard
 2. 使用你的账号登录
 
 #### 步骤 2：获取 Cookie
@@ -166,6 +166,7 @@ cp aicodemirror-config.example.json aicodemirror-config.json
 
 ```json
 {
+  "base_url": "https://www.aicodemirror.ai",
   "cookies": "你的Cookie字符串",
   "credits_cache": {
     "data": {
@@ -196,7 +197,8 @@ cp aicodemirror-config.example.json aicodemirror-config.json
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `cookies` | string | - | aicodemirror.com 的认证 Cookie<br/>⚠️ 包含敏感信息，不要分享 |
+| `base_url` | string | `https://www.aicodemirror.ai` | 官网地址，用于请求余额/用量接口。<br/>余额接口只有官网域名支持（`ANTHROPIC_BASE_URL` 可能是中转/代理域名，不适用）。<br/>官方若更换域名，只需修改此字段即可，无需改代码。 |
+| `cookies` | string | - | 官网的认证 Cookie<br/>⚠️ 包含敏感信息，不要分享 |
 
 **缓存数据 (v2.0 更新)：**
 
@@ -217,11 +219,14 @@ cp aicodemirror-config.example.json aicodemirror-config.json
 
 **手动编辑提示：**
 
-通常你只需要手动编辑 `cookies` 字段，其他字段由插件自动管理，建议不要手动修改。
+通常你只需要手动编辑 `cookies` 字段（以及官方换域名时的 `base_url` 字段），其余字段由插件自动管理，建议不要手动修改。
+
+> 💡 `base_url` 可通过 `save-cookie.js` 的第二个参数写入，例如：
+> `node tools/save-cookie.js '你的Cookie' https://www.aicodemirror.ai`
+> 不传时若配置中尚无 `base_url`，会自动写入默认官网域名。
 
 ### 环境变量支持
 
-- `ANTHROPIC_BASE_URL`：API 基础地址，包含 `aicodemirror.com` 时才显示信息
 - `ANTHROPIC_MODEL`：当前模型，优先级高于配置文件
 - `CLAUDE_OUTPUT_STYLE`：输出风格，优先级高于配置文件
 
@@ -672,7 +677,7 @@ node credit-status.js 2> debug.log  # 调试信息会写入 debug.log
 ### 1. 状态栏不显示信息
 
 **检查项目：**
-- 确认 `ANTHROPIC_BASE_URL` 包含 `aicodemirror.com`
+- 确认 `aicodemirror-config.json` 中的 `base_url` 为正确的官网地址（如 `https://www.aicodemirror.ai`）
 - 检查配置文件是否存在
 - 验证 Cookie 是否有效（重新获取）
 
@@ -713,7 +718,7 @@ cd ~/.claude/cc-aicodemirror-statusline-plus                 # Linux/macOS
 node credit-status.js --debug
 
 # 手动测试网络连接
-curl -H "Cookie: 你的Cookie" https://www.aicodemirror.com/api/user/profile
+curl -H "Cookie: 你的Cookie" https://www.aicodemirror.ai/api/user/profile
 
 # 重新获取Cookie
 node save-cookie.js "新Cookie"
@@ -726,7 +731,7 @@ node save-cookie.js "新Cookie"
 **原因：** API请求失败，可能是：
 - Cookie已过期或无效
 - 网络连接中断
-- aicodemirror.com服务异常
+- aicodemirror 服务异常
 
 **解决方法：**
 1. **检查Cookie有效性**
@@ -738,7 +743,7 @@ node save-cookie.js "新Cookie"
 2. **测试网络连接**
    ```bash
    # 测试能否访问目标网站
-   curl https://www.aicodemirror.com/api/user/profile
+   curl https://www.aicodemirror.ai/api/user/profile
    ```
 
 3. **使用调试模式定位问题**
@@ -804,7 +809,7 @@ cat ~/.claude/settings.json | grep model
 
 1. **隐私安全**：Cookie 包含认证信息，请妥善保管，不要分享给他人
 2. **缓存机制**：数据信息会缓存30秒，避免频繁API调用
-3. **网络要求**：需要能够访问 aicodemirror.com 的网络环境
+3. **网络要求**：需要能够访问 aicodemirror 官网的网络环境
 4. **版本兼容**：支持 Node.js 14+ 版本
 
 ## 🤝 贡献

--- a/aicodemirror-config.example.json
+++ b/aicodemirror-config.example.json
@@ -1,4 +1,5 @@
 {
+  "base_url": "https://www.aicodemirror.ai",
   "cookies": "你的Cookie字符串,使用 save-cookie.js 保存",
   "creditThreshold": 1000,
   "autoResetEnabled": false,

--- a/credit-status.js
+++ b/credit-status.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Claude Code 积分状态栏脚本
- * 用途: 在状态栏显示 aicodemirror.com 的积分余额
+ * 用途: 在状态栏显示 aicodemirror 官网的积分余额
  * 版本: v1.3 (Node.js)
  */
 

--- a/credit-status.js
+++ b/credit-status.js
@@ -27,6 +27,23 @@ function consoleLog(...logs) {
   }
 }
 
+// 余额接口只有官网域名支持，中转/代理域名（ANTHROPIC_BASE_URL）不支持。
+// 因此官网域名统一从配置文件 aicodemirror-config.json 的 base_url 读取，
+// 以后官方再换域名，只需改配置里的 base_url 即可，无需改代码。
+const DEFAULT_BASE_URL = 'https://www.aicodemirror.ai';
+
+// 读取配置中的官网 base_url（缺省时回退到默认值）
+function getConfiguredBaseUrl() {
+    const url = getConfigField('base_url', '') || '';
+    return url.trim() || DEFAULT_BASE_URL;
+}
+
+// 从配置的 base_url 解析出 API 请求主机名
+function getApiHostname() {
+    const match = getConfiguredBaseUrl().match(/https?:\/\/([^\/]+)/i);
+    return match ? match[1] : 'www.aicodemirror.ai';
+}
+
 function getCredits(cookies) {
     return new Promise((resolve) => {
         if (!cookies) {
@@ -49,7 +66,7 @@ function getCredits(cookies) {
         }
 
         const options = {
-            hostname: 'www.aicodemirror.com',
+            hostname: getApiHostname(),
             path: '/api/user/profile',
             method: 'GET',
             headers: {
@@ -133,7 +150,7 @@ function getUsageChart(cookies) {
         }
 
         const options = {
-            hostname: 'www.aicodemirror.com',
+            hostname: getApiHostname(),
             path: '/api/user/usage/chart?hours=1',
             method: 'GET',
             headers: {
@@ -199,18 +216,8 @@ function getUsageChart(cookies) {
 }
 
 function getDisplayUrl() {
-    const baseUrl = process.env.ANTHROPIC_BASE_URL || '';
-    if (baseUrl) {
-        if (baseUrl.includes('aicodemirror.com')) {
-            return 'aicodemirror.com';
-        } else {
-            const match = baseUrl.match(/https?:\/\/([^\/]+)/);
-            if (match) {
-                return match[1];
-            }
-        }
-    }
-    return 'anthropic.com';
+    // 显示官网域名（来自配置 base_url），去掉 www. 前缀更简洁
+    return getApiHostname().replace(/^www\./i, '');
 }
 
 function getValidSession() {
@@ -219,8 +226,8 @@ function getValidSession() {
 }
 
 function checkAnthropicBaseUrl() {
-    const baseUrl = process.env.ANTHROPIC_BASE_URL || '';
-    return baseUrl.includes('aicodemirror.com');
+    // 是否走完整余额功能：以配置的官网 base_url 为准（余额接口只有官网支持）
+    return /aicodemirror\.[a-z]+/i.test(getConfiguredBaseUrl());
 }
 
 async function main() {
@@ -229,7 +236,7 @@ async function main() {
         if (!checkAnthropicBaseUrl()) {
             const currentUrl = getDisplayUrl();
             const currentModel = getCurrentModel();
-            consoleLog(`${currentModel} | ${currentUrl}`);
+            console.log(`${currentModel} | ${currentUrl}`);
             return;
         }
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,11 +15,11 @@ node tools/save-cookie.js "你的Cookie字符串"
 **详细步骤：**
 
 1. **获取 Cookie：**
-   - 浏览器打开 https://www.aicodemirror.com/dashboard
+   - 浏览器打开 https://www.aicodemirror.ai/dashboard
    - 按 `F12` 打开开发者工具
    - 切换到 `Network` (网络) 标签
    - 刷新页面 (`F5`)
-   - 点击任意一个 `www.aicodemirror.com` 域名的请求
+   - 点击任意一个 `www.aicodemirror.ai` 域名的请求
    - 在 `Request Headers` 中找到 `Cookie` 字段
    - 复制完整的 Cookie 值
 

--- a/tools/calculate-usage.js
+++ b/tools/calculate-usage.js
@@ -4,8 +4,14 @@
 
 const { getConfigField } = require('../config-manager');
 
+// 官网域名从配置 base_url 读取，兼容换域名（缺省回退到默认官网）
+function getBaseUrl() {
+  return (getConfigField('base_url', '') || '').trim().replace(/\/+$/, '') || 'https://www.aicodemirror.ai';
+}
+
 async function getTodayUsage() {
-  const url = 'https://www.aicodemirror.com/api/user/usage/chart?hours=24';
+  const baseUrl = getBaseUrl();
+  const url = `${baseUrl}/api/user/usage/chart?hours=24`;
 
   // 从配置文件读取 Cookie
   const cookies = getConfigField('cookies', null);
@@ -23,7 +29,7 @@ async function getTodayUsage() {
     'cookie': cookies,
     'pragma': 'no-cache',
     'priority': 'u=1, i',
-    'referer': 'https://www.aicodemirror.com/dashboard/usage',
+    'referer': `${baseUrl}/dashboard/usage`,
     'sec-ch-ua': '"Microsoft Edge";v="143", "Chromium";v="143", "Not A(Brand";v="24"',
     'sec-ch-ua-mobile': '?0',
     'sec-ch-ua-platform': '"Windows"',

--- a/tools/daily-usage.js
+++ b/tools/daily-usage.js
@@ -8,9 +8,14 @@
 
 const { getConfigField } = require('../config-manager');
 
+// 官网域名从配置 base_url 读取，兼容换域名（缺省回退到默认官网）
+function getBaseUrl() {
+  return (getConfigField('base_url', '') || '').trim().replace(/\/+$/, '') || 'https://www.aicodemirror.ai';
+}
+
 // 从 API 获取数据（24小时）
 async function fetchFromAPI() {
-  const url = 'https://www.aicodemirror.com/api/user/usage?hours=24';
+  const url = `${getBaseUrl()}/api/user/usage?hours=24`;
 
   // 从配置文件读取 Cookie
   const cookies = getConfigField('cookies', null);
@@ -34,7 +39,9 @@ async function fetchFromAPI() {
 
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
 
-    return await response.json();
+    const json = await response.json();
+    // 接口返回 {data: [...]}，兼容旧版直接返回数组的情况
+    return Array.isArray(json) ? json : (json.data || json);
   } catch (error) {
     console.error('API 请求失败:', error.message);
     process.exit(1);

--- a/tools/save-cookie.js
+++ b/tools/save-cookie.js
@@ -8,21 +8,27 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { spawn } = require('child_process');
-const { setConfigField, CONFIG_FILE } = require('../config-manager');
+const { updateConfig, getConfigField, CONFIG_FILE } = require('../config-manager');
+
+const DEFAULT_BASE_URL = 'https://www.aicodemirror.ai';
 
 function saveCookie() {
-    if (process.argv.length !== 3) {
-        console.log("使用方法: node save-cookie.js '你的Cookie字符串'");
+    if (process.argv.length < 3 || process.argv.length > 4) {
+        console.log("使用方法: node save-cookie.js '你的Cookie字符串' [官网base_url]");
         console.log();
         console.log("📝 步骤：");
-        console.log("1. 浏览器登录 https://www.aicodemirror.com/dashboard");
-        console.log("2. F12 -> Network -> 刷新页面 -> www.aicodemirror.com域名的任意接口");
+        console.log(`1. 浏览器登录 ${DEFAULT_BASE_URL}/dashboard`);
+        console.log("2. F12 -> Network -> 刷新页面 -> 官网域名的任意接口");
         console.log("3. 复制Cookie值");
         console.log("4. node save-cookie.js 'Cookie内容'");
+        console.log();
+        console.log(`💡 官网若换域名，可传入第二个参数覆盖，例如：`);
+        console.log(`   node save-cookie.js 'Cookie内容' https://www.aicodemirror.ai`);
         return false;
     }
 
     const cookie = process.argv[2].trim();
+    const baseUrl = (process.argv[3] || '').trim();
 
     if (!cookie) {
         console.log("❌ Cookie不能为空");
@@ -31,7 +37,15 @@ function saveCookie() {
 
     // 使用配置管理模块保存 Cookie（保留其他字段）
     try {
-        const success = setConfigField('cookies', cookie);
+        // 传入了 base_url 就一并更新；否则若配置里还没有则写入默认值
+        const configUpdate = { cookies: cookie };
+        if (baseUrl) {
+            configUpdate.base_url = baseUrl;
+        } else if (!getConfigField('base_url', '')) {
+            configUpdate.base_url = DEFAULT_BASE_URL;
+        }
+
+        const success = updateConfig(configUpdate);
 
         if (!success) {
             throw new Error('写入配置文件失败');
@@ -39,6 +53,7 @@ function saveCookie() {
 
         console.log(`✅ Cookie已保存到: ${CONFIG_FILE}`);
         console.log(`📏 Cookie长度: ${cookie.length} 字符`);
+        console.log(`🌐 官网域名(base_url): ${configUpdate.base_url || getConfigField('base_url', DEFAULT_BASE_URL)}`);
 
         // 测试
         console.log("\n🧪 正在测试...");


### PR DESCRIPTION
## 背景

AICodeMirror 官网域名从 `aicodemirror.com` 升级为 `aicodemirror.ai`（原 .com 需代理才能在中国大陆访问）。余额/用量接口只有官网域名支持，而 `ANTHROPIC_BASE_URL` 往往是中转/代理域名，不能用来推导官网域名。当前插件多处写死 `aicodemirror.com`，域名升级后状态栏无法显示余额。

## 改动

统一从 `aicodemirror-config.json` 的 `base_url` 字段读取官网域名，以后官方再换域名只需改这一处配置，无需改代码。

**代码：**
- **credit-status.js**：新增 `getConfiguredBaseUrl` / `getApiHostname`；profile 与 usage/chart 请求、`getDisplayUrl`、`checkAnthropicBaseUrl` 均改为基于配置的 base_url
- **tools/save-cookie.js**：支持可选第二参数写入/更新 `base_url`，缺省回退到默认官网
- **tools/calculate-usage.js**：请求 URL 与 referer 改用配置 base_url
- **tools/daily-usage.js**：请求 URL 改用配置 base_url；并兼容 `/api/user/usage` 返回结构由裸数组变为 `{data:[...]}`

**文档：**
- **README.md**：配置结构 JSON 与字段表补充 `base_url` 说明；移除“`ANTHROPIC_BASE_URL` 包含 `aicodemirror.com` 才显示”的过时描述；登录、故障排除、curl 示例统一改为官网 `.ai` 域名
- **aicodemirror-config.example.json**：模板补充 `base_url` 默认值
- **tools/README.md**：获取 Cookie 步骤域名改为 `.ai`

## 测试

本地 macOS + Node v22 实测（`base_url` = `https://www.aicodemirror.ai`）：

- 状态栏正常显示余额与用量
- `tools/calculate-usage.js`、`tools/daily-usage.js` 均正常输出

## 兼容性

`base_url` 缺省时回退到官网默认域名；`daily-usage.js` 同时兼容新旧两种接口返回结构。